### PR TITLE
Add option to choose PACS model

### DIFF
--- a/body_organ_analysis/_version.py
+++ b/body_organ_analysis/_version.py
@@ -1,3 +1,3 @@
 # This file was generated automatically, do not edit
-__version__ = "N/A"
-__githash__ = "N/A"
+__version__ = "0.1.4"
+__githash__ = "98f8c54"

--- a/docker-compose-win.yml
+++ b/docker-compose-win.yml
@@ -31,6 +31,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_DATABASE
       - PREDICT_FAST
+      - PACS_MODEL
       # Output vars
       - PATIENT_INFO_IN_OUTPUT
       - SMB_DIR_OUTPUT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_DATABASE
       - PREDICT_FAST
+      - PACS_MODEL
       # Output vars
       - PATIENT_INFO_IN_OUTPUT
       - SMB_DIR_OUTPUT

--- a/documentation/environment_variables.md
+++ b/documentation/environment_variables.md
@@ -59,7 +59,7 @@ mode and that the outputs can be easily accessed. You can get it with
 then the outputs will be owned by root and it may be needed to change the
 ownership.
 - `PATIENT_INFO_IN_OUTPUT`: This option changes how the output folder structure
-looks like. If this variable is `True`, then the folder structure will look like
+looks like. If this variable is `true`, then the folder structure will look like
 the following:
   - AET (the name that you have given to this endpoint in your PACS, more on
   this later)
@@ -95,6 +95,14 @@ the following:
   Doe, 1970), then you will have clashes.
   - The output folders will not be anonymized and will contain the patient name
   and birthdate.
+- `PREDICT_FAST`: If set to `true`, TotalSegmentator will be executed in fast mode.
+- `PACS_MODEL`: Defines which models are executed during inference.  
+  Multiple models can be specified by separating them with a `+`
+(e.g. `body+total+bca`).  
+  Available models are:
+  - `total`: Runs the full-body TotalSegmentator model.
+  - `body`: Runs the body-parts model to segment head, torso and legs.
+  - `bca`: Runs the body composition analysis model.
 
 ## Monitoring Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "poetry-core>=1" ]
 
 [tool.poetry]
 name = "body-organ-analysis"
-version = "0.1.4"
+version = "0.1.5"
 license = "Apache-2.0"
 description = "BOA is a tool for segmentation of CT scans developed by the SHIP-AI group at the Institute for Artificial Intelligence in Medicine (https://ship-ai.ikim.nrw/). Combining the TotalSegmentator and the Body Composition Analysis, this tool is capable of analyzing medical images and identifying the different structures within the human body, including bones, muscles, organs, and blood vessels."
 authors = [ "Jannis Straus <jannis.straus@uk-essen.de>" ]

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -198,7 +198,17 @@ def build_excel(
 ) -> Tuple[Path, Dict[str, Any]]:
     # Setup before calling
     start = time()
-    models = [*BASE_MODELS, "bca"]
+    all_models = [*BASE_MODELS, "bca"]
+    if "PACS_MODEL" in os.environ:
+        models = os.environ["PACS_MODEL"].split("+")
+        missing = set(models) - set(all_models)
+        if missing:
+            logger.error(
+                f"The following PACS_MODEL entries are invalid: {missing}. "
+                f"Available models are: {all_models}."
+            )
+    else:
+        models = all_models
     excel_path, stats = analyze_ct(
         input_folder=input_data_folder,
         processed_output_folder=output_folder,


### PR DESCRIPTION
The environment variable `PACS_MODEL` defines which models are executed during inference. Multiple models can be specified by separating them with a `+` (e.g. `body+total+bca`).  
Available models are:
- `total`: Runs the full-body TotalSegmentator model.
- `body`: Runs the body-parts model to segment head, torso and legs.
- `bca`: Runs the body composition analysis model.